### PR TITLE
feat(shop-brand): 브랜드 소개

### DIFF
--- a/shop-api/src/main/java/livart/shop/brand/BrandController.java
+++ b/shop-api/src/main/java/livart/shop/brand/BrandController.java
@@ -1,0 +1,30 @@
+package livart.shop.brand;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import livart.common.dto.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shop/brand")
+@Tag(name = "브랜드 소개")
+@CrossOrigin(origins = {
+        "http://localhost:3000",
+        "https://staging.artliving.store",
+        "https://artliving.store"
+})
+public class BrandController {
+
+    private final BrandService brandService;
+
+    @GetMapping
+    @Operation(summary = "브랜드 소개 이미지 1개 조회(공개)")
+    public ResponseEntity<ApiResponse<BrandViewResponse>> getBrand() {
+        BrandViewResponse body = brandService.get();
+        String etag = (body.updatedAt() == null) ? "\"0\"" : "\"" + body.updatedAt().hashCode() + "\"";
+        return ResponseEntity.ok().eTag(etag).body(ApiResponse.ok(body));
+    }
+}

--- a/shop-api/src/main/java/livart/shop/brand/BrandService.java
+++ b/shop-api/src/main/java/livart/shop/brand/BrandService.java
@@ -1,0 +1,28 @@
+package livart.shop.brand;
+
+import livart.common.domain.design.entity.Brand;
+import livart.common.domain.design.repository.BrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BrandService {
+
+    private final BrandRepository brandRepository; //
+
+    public BrandViewResponse get() {
+        return brandRepository.findById(1L)
+                .map(this::toDto)
+                .orElseGet(() -> new BrandViewResponse(null, null, null));
+    }
+
+    private BrandViewResponse toDto(Brand b) {
+        String alt = (b.getFileName() != null && !b.getFileName().isBlank())
+                ? b.getFileName() : "브랜드 소개 이미지";
+        String updatedAt = (b.getUpdatedAt() == null) ? null : b.getUpdatedAt().toString();
+        return new BrandViewResponse(b.getImageUrl(), alt, updatedAt);
+    }
+}

--- a/shop-api/src/main/java/livart/shop/brand/BrandViewResponse.java
+++ b/shop-api/src/main/java/livart/shop/brand/BrandViewResponse.java
@@ -1,0 +1,3 @@
+package livart.shop.brand;
+public record BrandViewResponse(String imageUrl, String alt, String updatedAt) {}
+

--- a/shop-api/src/main/java/livart/shop/faq/dto/response/FaqItemResponse.java
+++ b/shop-api/src/main/java/livart/shop/faq/dto/response/FaqItemResponse.java
@@ -1,0 +1,11 @@
+package livart.shop.faq.dto.response;
+
+import java.time.LocalDateTime;
+
+public record FaqItemResponse(
+        Long id,
+        String category,
+        String question,
+        String answer,
+        LocalDateTime updatedAt
+) {}


### PR DESCRIPTION
## 변경
- shop-api: 브랜드 소개 조회 API 추가
- 응답: ApiResponse<BrandViewResponse>
- 캐시: ETag/304 지원
- 공통 엔티티/레포: common-lib 재사용